### PR TITLE
implement demo tools pane basic display mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 commit.txt
 
 commit
+
+.DS_Store

--- a/demo/client/App.jsx
+++ b/demo/client/App.jsx
@@ -4,12 +4,11 @@ import DemoContainer from './components/DemoContainer';
 const App = () => (
   <div className="app">
     <nav>
+      <span>demo 1</span>
       {' '}
-      <span>demo 1</span> 
-{' '}
-<span>demo 2</span> 
-{' '}
-<span>demo 3</span>
+      <span>demo 2</span>
+      {' '}
+      <span>demo 3</span>
     </nav>
 
     <DemoContainer />

--- a/demo/client/components/DemoTools.jsx
+++ b/demo/client/components/DemoTools.jsx
@@ -1,8 +1,60 @@
 import React, { useState, useEffect } from 'react';
 
-const DemoTools = () => (
+import StateDisplay from './StateDisplay';
+
+const stateData = {
+  number: 5182836,
+  string: '٩(｡•́‿•̀｡)۶',
+  boolean: true,
+  'undefined val': undefined,
+  'null val': null,
+
+
+  array: [true, null, 12345, 'wow'],
+  object: {
+    nested: {
+      key: {
+        value: {
+          pairs: '( ´_ゝ`)',
+        },
+      },
+    },
+  },
+};
+
+const cacheData = {
+  'Post:5': {
+    id: 5,
+    some: 'data',
+    about: 'a',
+    neat: 'book',
+  },
+  'Post:7': {
+    id: 7,
+    here: 'is',
+    more: 'data',
+    about: 'a',
+    post: 'wow',
+  },
+  'Post:14': {
+    id: 14,
+    some: 'fake',
+    stuff: 'here',
+    too: '...',
+  },
+  'Post:3': {
+    id: 3,
+    some: 'data',
+    about: 'a',
+    neat: 'book',
+  },
+};
+
+const DemoTools = props => (
   <div className="demo-tools">
-    This is the Demo Tools
+    <StateDisplay title="State" data={stateData} />
+    <StateDisplay title="Cache" data={cacheData} />
+    <StateDisplay title="Queries" data={stateData} />
   </div>
 );
 

--- a/demo/client/components/DemoTools.jsx
+++ b/demo/client/components/DemoTools.jsx
@@ -2,8 +2,12 @@ import React, { useState, useEffect } from 'react';
 
 import StateDisplay from './StateDisplay';
 
+
 const stateData = {
   number: 5182836,
+  float: 3.14159,
+  notNumber: NaN,
+  date: new Date(Date.now()).toDateString(),
   string: '٩(｡•́‿•̀｡)۶',
   boolean: true,
   'undefined val': undefined,

--- a/demo/client/components/StateDisplay.jsx
+++ b/demo/client/components/StateDisplay.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import JSONTree from 'react-json-tree';
+import ReactJson from 'react-json-view';
+
+
+const StateDisplay = ({ data, title }) => (
+  <div className="state-display">
+    <h1>{title}</h1>
+    <div className="json-view">
+      <ReactJson
+        src={data}
+        name={null}
+        theme="summerfruit:inverted"
+        iconStyle="triangle"
+        indentWidth={2}
+        collapsed={1}
+        enableClipboard={false}
+        displayObjectSize={false}
+        displayDataTypes={false}
+        groupArraysAfterLength={50}
+      />
+    </div>
+  </div>
+);
+
+export default StateDisplay;

--- a/demo/client/index.js
+++ b/demo/client/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import '../dist/style.css';
 import App from './App';
+
 
 ReactDOM.render(
   <App />,

--- a/demo/dist/style.css
+++ b/demo/dist/style.css
@@ -1,17 +1,22 @@
 body {
   margin: 0;
 }
+#root {
+  background-color: green;
+  width: 100%;
+  height: 100vh;
+}
+
 .app {
   display: grid;
-  grid-template-rows: 100px 1fr;
-  height: 100vh;
-
+  grid-template-rows: 80px 1fr;
   background-color: red;
+  height: 100vh;
 }
 
 .demo-container {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 3fr 1fr;
   background-color: blue;
 }
 
@@ -20,10 +25,29 @@ body {
 }
 
 .demo-tools {
-  background-color: green;
+  background-color: white;
+  display: grid;
+  grid-template-rows: auto auto auto;
+  /* max-height: 100vh - 80px; */
+  height: (100vh - 80px);
 }
 
-#root {
-  height: 100vh;
-  background-color: aqua;
+.state-display {
+  background: #ddd;
+  /* border: 1px solid blue; */
+  display: flex;
+  flex-direction: column;
+}
+
+.state-display h1 {
+  align-self: center;
+  margin-bottom: 0;
+}
+
+.json-view {
+  /* border: 1px solid black; */
+
+  margin-left: 1rem;
+  margin-right: 1rem;
+  min-width: 275px;
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -32,6 +32,8 @@
     "graphql": "^14.1.1",
     "pg-promise": "^8.5.5",
     "react": "^16.8.1",
-    "react-dom": "^16.8.1"
+    "react-dom": "^16.8.1",
+    "react-json-tree": "^0.11.2",
+    "react-json-view": "^1.19.1"
   }
 }

--- a/demo/server/Models/db.js
+++ b/demo/server/Models/db.js
@@ -1,5 +1,5 @@
-require('dotenv').config();
 const pgp = require('pg-promise')();
+
 
 const db = pgp(process.env.DB_URI);
 


### PR DESCRIPTION

Built out the demo tools component display. Created a StateDisplay
component to display JSON information dynamically for 3 fields: 
- Application State
- Current Cache State
- Query Log

Query log will need a reconfigure to show both the query, and the data
returned from the server.

In addition to some basic styling on the DemoTools and 
StateDisplay components, some additional layout styling was added to
the overall document to handle some viewport issues. The updated styles
should ensure that the app is always filling the viewport, without 
spilling over.

Miscellaneous configuration updates:

- removed redundant call to dotenv from db.js. 
  Only need the one call in server/index.js

- imported stylesheet to client index
  Allows styles to be detected for hot reloading

- Added .DS_Store to .gitignore
  It's a system dependent that's automatically generated by OSX